### PR TITLE
Export `BINARY_DIR`

### DIFF
--- a/cmake-ports.cmake
+++ b/cmake-ports.cmake
@@ -153,6 +153,8 @@ function(declare_port specifier result)
     AUTOTOOLS
   )
 
+  set(one_value_keywords BINARY_DIR)
+
   set(multi_value_keywords
     ARGS
     BYPRODUCTS
@@ -162,7 +164,7 @@ function(declare_port specifier result)
   )
 
   cmake_parse_arguments(
-    PARSE_ARGV 1 ARGV "${option_keywords}" "" "${multi_value_keywords}"
+    PARSE_ARGV 1 ARGV "${option_keywords}" "${one_value_keywords}" "${multi_value_keywords}"
   )
 
   parse_fetch_specifier(${specifier} target args)
@@ -200,6 +202,7 @@ function(declare_port specifier result)
     STEP_TARGETS install
     INSTALL_BYPRODUCTS ${ARGV_BYPRODUCTS}
     DEPENDS ${ARGV_DEPENDS}
+    BINARY_DIR ${ARGV_BINARY_DIR}
     UPDATE_DISCONNECTED ON
     LOG_DOWNLOAD ON
     LOG_UPDATE ON


### PR DESCRIPTION
Required at: https://github.com/holepunchto/bare-link/blob/f8ae7964469836bc384077c97dd3e976ca8608f9/cmake/ports/patchelf/port.cmake#L9

The idea is to give to the `declare_port` the flexibility to choose where to consume the compilation output.