### PR TITLE
feat: add ENTRYPOINT arg

### DIFF
--- a/cmake-ports.cmake
+++ b/cmake-ports.cmake
@@ -248,7 +248,7 @@ function(declare_port specifier result)
 
   if(ARGV_MESON)
     configure_meson_port()
-  elseif(ARGV_AUTOTOOLS OR ARGV_ENTRYPOINT)
+  elseif(ARGV_AUTOTOOLS)
     configure_autotools_port()
   elseif(ARGV_ZIG)
     configure_zig_port()

--- a/cmake-ports.cmake
+++ b/cmake-ports.cmake
@@ -137,9 +137,15 @@ macro(configure_autotools_port)
 
   list(APPEND configure_args ${ARGV_ARGS})
 
+  if(ARGV_ENTRYPOINT)
+    set(configure_script ${ARGV_ENTRYPOINT})
+  else()
+    set(configure_script ${prefix}/src/${target}/configure)
+  endif()
+
   list(APPEND args
     CONFIGURE_COMMAND
-      ${CMAKE_COMMAND} -E env ${env} ${bash} ${prefix}/src/${target}/configure ${configure_args}
+      ${CMAKE_COMMAND} -E env ${env} ${bash} ${configure_script} ${configure_args}
     BUILD_COMMAND
       ${CMAKE_COMMAND} -E env ${env} ${make} --jobs 8
     INSTALL_COMMAND
@@ -205,6 +211,10 @@ function(declare_port specifier result)
     ZIG
   )
 
+  set(one_value_keywords
+    ENTRYPOINT
+  )
+
   set(multi_value_keywords
     ARGS
     BYPRODUCTS
@@ -214,7 +224,7 @@ function(declare_port specifier result)
   )
 
   cmake_parse_arguments(
-    PARSE_ARGV 1 ARGV "${option_keywords}" "" "${multi_value_keywords}"
+    PARSE_ARGV 1 ARGV "${option_keywords}" "${one_value_keywords}" "${multi_value_keywords}"
   )
 
   parse_fetch_specifier(${specifier} target args)
@@ -238,7 +248,7 @@ function(declare_port specifier result)
 
   if(ARGV_MESON)
     configure_meson_port()
-  elseif(ARGV_AUTOTOOLS)
+  elseif(ARGV_AUTOTOOLS OR ARGV_ENTRYPOINT)
     configure_autotools_port()
   elseif(ARGV_ZIG)
     configure_zig_port()


### PR DESCRIPTION
It would allow me to do:

```cmake
configure_file("${entrypoint_in}" "${entrypoint}" @ONLY)
file(CHMOD "${entrypoint}" PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ)

declare_port(
  "git:git.ffmpeg.org/ffmpeg#n7.1"
  ffmpeg
  ENTRYPOINT ${entrypoint}
  DEPENDS ${depends}
  BYPRODUCTS ${byproducts}
  ARGS ${args}
  ENV ${env}
)
```